### PR TITLE
Fix dev server endless recompile loop (drop distDir override)

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -54,10 +54,28 @@ const nextConfig = {
   // basePath: '/your-subdirectory',
   // assetPrefix: '/your-subdirectory/',
   
-  // Output Directory
-  distDir: 'out',
-  // ↑ Directory where static files are generated
-  // This is where 'npm run build' puts the exportable files
+  // NOTE: distDir is intentionally left at the default ('.next'). With
+  // `output: 'export'`, `next build` already emits the static site to `out/`,
+  // so overriding distDir to 'out' was redundant — and it made the dev server
+  // write its build artifacts into a folder it also watches, causing an endless
+  // recompile loop. Netlify still publishes `out/`.
+
+  // Keep the dev file-watcher from reacting to generated/output folders.
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.watchOptions = {
+        ...config.watchOptions,
+        ignored: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/.next/**',
+          '**/out/**',
+        ],
+        aggregateTimeout: 300,
+      }
+    }
+    return config
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Problem
`npm run dev` recompiles ~400 modules every ~400ms continuously, even while the server is idle and no files are being edited — slowing the whole dev experience.

## Root cause
`next.config.mjs` set `distDir: 'out'`. That is:
1. **Redundant** — with `output: 'export'`, Next already builds in `.next` and exports the static site to `out/`.
2. **Harmful** — it points the dev build output into a folder the dev file-watcher monitors, so each compile writes artifacts that trigger the next compile. An endless rebuild loop.

Reproduced: after loading `/`, the idle server logged `✓ Compiled in ~400ms (411 modules)` over and over with no edits.

## Fix
- Remove the `distDir` override (build dir returns to `.next`; the static export still lands in `out/`, so Netlify's `publish = "out"` is unaffected).
- Add explicit dev `watchOptions.ignored` for `node_modules`, `.git`, `.next`, `out`.

## Verification
- Idle dev server after the fix: only `GET / 200 (~40ms)` — **zero recompiles**.
- `npm run build` still produces a complete `out/` (`index.html`, `scripts/index.html`, `data/scripts.json` with 15 tools / 22 scripts, `sw.js`).

Note: the ~400 module count itself is normal for a Radix/shadcn/lucide app — the bug was the *repeated* recompilation, not the count.